### PR TITLE
Make min and max value metrics return options

### DIFF
--- a/docs-source/available-metrics.md
+++ b/docs-source/available-metrics.md
@@ -9,6 +9,8 @@ The available metrics are:
 * `CountDistinctValuesMetric` - count the distinct values across a given set of columns
 * `ComplianceMetric` - calculate the fraction of rows that comply with the given condition
 * `DistinctnessMetric` - calculate the fraction of rows that are unique
+* `MinValueMetric` - calculate the minimum value in a given column. Returns None if no rows in the dataset
+* `MaxValueMetric` - calculate the maximum value in a given column. Returns None if no rows in the dataset
 
 With most metrics a filter can be applied before the metric gets calculated - you can see an example of this below. 
 
@@ -68,3 +70,17 @@ import com.github.timgent.dataflare.metrics.MetricFilter
 
 DistinctnessMetric(List("firstName", "surname"), MetricFilter.noFilter)
 ```
+
+## MinValueMetric and MaxValueMetric
+These calculate the minimum/maximum value of a given column in a Dataset. You must specify if they operate on columns
+with Ints or Longs (by using OptLongMetric) or Doubles (by using OptDoubleMetric). A filter can be provided For example:
+```scala mdoc:compile-only
+import com.github.timgent.dataflare.metrics.MetricDescriptor.MinValueMetric
+import com.github.timgent.dataflare.metrics.MetricFilter
+import com.github.timgent.dataflare.metrics.MetricValue.OptLongMetric
+
+MinValueMetric[OptLongMetric]("age", MetricFilter.noFilter)
+```
+The reason these checks use OptLongMetric or OptDouble metric is because in the case of an empty Dataset the only
+sensible metric value to calculate is None. These types of metric value calculate metrics that are options to
+acknowledge this possibility.

--- a/src/main/scala/com/github/timgent/dataflare/checks/metrics/SingleMetricCheck.scala
+++ b/src/main/scala/com/github/timgent/dataflare/checks/metrics/SingleMetricCheck.scala
@@ -195,7 +195,7 @@ object SingleMetricCheck {
   ): SingleMetricCheck[OptDoubleMetric] = minValueCheck[OptDoubleMetric](threshold, onColumn, filter)
 
   /**
-    * Checks the min value of a given column in a dataset after the given filter is applied
+    * Checks the max value of a given column in a dataset after the given filter is applied
     * is within the given threshold
     * @param threshold the threshold for what fraction of rows is acceptable
     * @param onColumn column on which min value needs to be computed

--- a/src/main/scala/com/github/timgent/dataflare/checks/metrics/SingleMetricCheck.scala
+++ b/src/main/scala/com/github/timgent/dataflare/checks/metrics/SingleMetricCheck.scala
@@ -147,7 +147,7 @@ object SingleMetricCheck {
       onColumn: String,
       filter: MetricFilter = MetricFilter.noFilter
   ): SingleMetricCheck[MV] =
-    thresholdBasedCheck[MV](SumValuesMetric(onColumn, filter), "MinValueCheck", threshold)
+    thresholdBasedCheck[MV](SumValuesMetric(onColumn, filter), "SumValueCheck", threshold)
 
   /**
     * Checks the min value of a given column in a dataset after the given filter is applied

--- a/src/main/scala/com/github/timgent/dataflare/metrics/MetricDescriptor.scala
+++ b/src/main/scala/com/github/timgent/dataflare/metrics/MetricDescriptor.scala
@@ -1,9 +1,16 @@
 package com.github.timgent.dataflare.metrics
 
 import cats.Show
-import com.github.timgent.dataflare.metrics.MetricCalculator.{ComplianceMetricCalculator, DistinctValuesMetricCalculator
-  , DistinctnessMetricCalculator, MaxValueMetricCalculator, MinValueMetricCalculator, SizeMetricCalculator, SumValuesMetricCalculator}
-import com.github.timgent.dataflare.metrics.MetricValue.NumericMetricValue
+import com.github.timgent.dataflare.metrics.MetricCalculator.{
+  ComplianceMetricCalculator,
+  DistinctValuesMetricCalculator,
+  DistinctnessMetricCalculator,
+  MaxValueMetricCalculator,
+  MinValueMetricCalculator,
+  SizeMetricCalculator,
+  SumValuesMetricCalculator
+}
+import com.github.timgent.dataflare.metrics.MetricValue.{NumericMetricValue, OptNumericMetricValue}
 
 /**
   * Describes the metric being calculated
@@ -80,7 +87,7 @@ object MetricDescriptor {
     * @param filter filter to be applied before the size is calculated
     * @tparam MV
     */
-  case class MinValueMetric[MV <: NumericMetricValue: MetricValueConstructor](
+  case class MinValueMetric[MV <: OptNumericMetricValue: MetricValueConstructor](
       onColumn: String,
       filter: MetricFilter = MetricFilter.noFilter
   ) extends MetricDescriptor
@@ -98,11 +105,11 @@ object MetricDescriptor {
     * @param filter
     * @tparam MV
     */
-  case class MaxValueMetric[MV <: NumericMetricValue: MetricValueConstructor](
-       onColumn: String,
-       filter: MetricFilter = MetricFilter.noFilter
-     ) extends MetricDescriptor
-    with Filterable {
+  case class MaxValueMetric[MV <: OptNumericMetricValue: MetricValueConstructor](
+      onColumn: String,
+      filter: MetricFilter = MetricFilter.noFilter
+  ) extends MetricDescriptor
+      with Filterable {
     override def metricCalculator: MaxValueMetricCalculator[MV] = MaxValueMetricCalculator[MV](onColumn, filter)
     override def toSimpleMetricDescriptor: SimpleMetricDescriptor =
       SimpleMetricDescriptor(metricName, Some(filter.filterDescription), onColumn = Some(onColumn))

--- a/src/main/scala/com/github/timgent/dataflare/metrics/MetricValue.scala
+++ b/src/main/scala/com/github/timgent/dataflare/metrics/MetricValue.scala
@@ -1,6 +1,6 @@
 package com.github.timgent.dataflare.metrics
 
-import com.github.timgent.dataflare.metrics.MetricValue.{DoubleMetric, LongMetric}
+import com.github.timgent.dataflare.metrics.MetricValue.{DoubleMetric, LongMetric, OptDoubleMetric, OptLongMetric}
 
 /**
   * Represents the value of a metric
@@ -12,6 +12,10 @@ sealed trait MetricValue {
 
 object MetricValue {
   sealed trait NumericMetricValue extends MetricValue
+  sealed trait OptNumericMetricValue extends MetricValue {
+    type U
+    type T = Option[U]
+  }
 
   case class LongMetric(value: Long) extends NumericMetricValue {
     type T = Long
@@ -19,6 +23,14 @@ object MetricValue {
   case class DoubleMetric(value: Double) extends NumericMetricValue {
     type T = Double
   }
+  case class OptLongMetric(value: Option[Long]) extends OptNumericMetricValue {
+    type U = Long
+  }
+
+  case class OptDoubleMetric(value: Option[Double]) extends OptNumericMetricValue {
+    type U = Double
+  }
+
   implicit val constructLongMetric: Long => LongMetric = value => LongMetric(value)
 }
 
@@ -35,7 +47,18 @@ object MetricValueConstructor {
     override def minValue: Long = Long.MinValue
     override def maxValue: Long = Long.MaxValue
     override def apply(value: Long): LongMetric = LongMetric(value)
-
+  }
+  implicit val OptLongMetricConstructor = new MetricValueConstructor[OptLongMetric] {
+    override def apply(value: Option[Long]): OptLongMetric = OptLongMetric(value)
+    override def zero: Option[Long] = None
+    override def maxValue: Option[Long] = Some(Long.MaxValue)
+    override def minValue: Option[Long] = Some(Long.MinValue)
+  }
+  implicit val OptDoubleMetricConstructor = new MetricValueConstructor[OptDoubleMetric] {
+    override def apply(value: Option[Double]): OptDoubleMetric = OptDoubleMetric(value)
+    override def zero: Option[Double] = None
+    override def maxValue: Option[Double] = Some(Double.MaxValue)
+    override def minValue: Option[Double] = Some(Double.MinValue)
   }
 
   implicit val DoubleMetricConstructor = new MetricValueConstructor[DoubleMetric] {

--- a/src/main/scala/com/github/timgent/dataflare/thresholds/AbsoluteThreshold.scala
+++ b/src/main/scala/com/github/timgent/dataflare/thresholds/AbsoluteThreshold.scala
@@ -28,5 +28,7 @@ case class AbsoluteThreshold[T: Ordering](lowerBound: Option[T], upperBound: Opt
 
 object AbsoluteThreshold {
   def apply[T: Ordering](lowerBound: T, upperBound: T): AbsoluteThreshold[T] = AbsoluteThreshold(Some(lowerBound), Some(upperBound))
+  def apply[T: Ordering](lowerBound: T, upperBound: Option[T]): AbsoluteThreshold[T] = AbsoluteThreshold(Some(lowerBound), upperBound)
+  def apply[T: Ordering](lowerBound: Option[T], upperBound: T): AbsoluteThreshold[T] = AbsoluteThreshold(lowerBound, Some(upperBound))
   def exactly[T: Ordering](t: T) = AbsoluteThreshold(Some(t), Some(t))
 }

--- a/src/test/scala/com/github/timgent/dataflare/checks/metrics/MetricsBasedCheckTest.scala
+++ b/src/test/scala/com/github/timgent/dataflare/checks/metrics/MetricsBasedCheckTest.scala
@@ -4,7 +4,7 @@ import com.github.timgent.dataflare.checks.CheckDescription.{DualMetricCheckDesc
 import com.github.timgent.dataflare.checks.DatasourceDescription.DualDsDescription
 import com.github.timgent.dataflare.checks.{CheckResult, CheckStatus, QcType, RawCheckResult}
 import com.github.timgent.dataflare.metrics.MetricDescriptor.{SizeMetric, SumValuesMetric}
-import com.github.timgent.dataflare.metrics.MetricValue.{DoubleMetric, LongMetric}
+import com.github.timgent.dataflare.metrics.MetricValue.{DoubleMetric, LongMetric, OptLongMetric}
 import com.github.timgent.dataflare.metrics.{MetricComparator, MetricDescriptor, MetricFilter, SimpleMetricDescriptor}
 import com.github.timgent.dataflare.thresholds.AbsoluteThreshold
 import com.github.timgent.dataflare.utils.CommonFixtures._
@@ -196,5 +196,9 @@ class MetricsBasedCheckTest extends AnyWordSpec with DatasetSuiteBase with Match
         )
       )
     }
+  }
+
+  "optThresholdBasedCheck" should {
+    //    TODO: Write a test!!
   }
 }

--- a/src/test/scala/com/github/timgent/dataflare/metrics/MetricCalculatorTest.scala
+++ b/src/test/scala/com/github/timgent/dataflare/metrics/MetricCalculatorTest.scala
@@ -1,7 +1,7 @@
 package com.github.timgent.dataflare.metrics
 
 import com.github.timgent.dataflare.metrics.MetricCalculator._
-import com.github.timgent.dataflare.metrics.MetricValue.{DoubleMetric, LongMetric}
+import com.github.timgent.dataflare.metrics.MetricValue.{DoubleMetric, LongMetric, OptLongMetric}
 import com.github.timgent.dataflare.utils.CommonFixtures._
 import com.holdenkarau.spark.testing.DatasetSuiteBase
 import org.apache.spark.sql.Dataset
@@ -193,24 +193,24 @@ class MetricCalculatorTest extends AnyWordSpec with DatasetSuiteBase with Matche
     "calculate the min of values for a given column" in {
       testMetricAggFunction(
         ds,
-        MinValueMetricCalculator[LongMetric]("number", MetricFilter.noFilter),
-        LongMetric(1)
+        MinValueMetricCalculator[OptLongMetric]("number", MetricFilter.noFilter),
+        OptLongMetric(Some(1))
       )
     }
 
     "apply the provided filter before calculating the minValue in a DataFrame" in {
       testMetricAggFunction(
         ds,
-        MinValueMetricCalculator[LongMetric]("number", MetricFilter(col("str") =!= lit("d"), "not d")),
-        LongMetric(2)
+        MinValueMetricCalculator[OptLongMetric]("number", MetricFilter(col("str") =!= lit("d"), "not d")),
+        OptLongMetric(Some(2))
       )
     }
 
     "handle Empty dataset for calculating the minValue in a DataFrame" in {
       testMetricAggFunction(
         ds.filter(col("number") === 5),
-        MinValueMetricCalculator[LongMetric]("number", MetricFilter(col("str") =!= lit("d"), "not d")),
-        LongMetric(0)
+        MinValueMetricCalculator[OptLongMetric]("number", MetricFilter(col("str") =!= lit("d"), "not d")),
+        OptLongMetric(None)
       )
     }
   }
@@ -226,24 +226,24 @@ class MetricCalculatorTest extends AnyWordSpec with DatasetSuiteBase with Matche
     "calculate the max of values for a given column" in {
       testMetricAggFunction(
         ds,
-        MaxValueMetricCalculator[LongMetric]("number", MetricFilter.noFilter),
-        LongMetric(4)
+        MaxValueMetricCalculator[OptLongMetric]("number", MetricFilter.noFilter),
+        OptLongMetric(Some(4))
       )
     }
 
     "apply the provided filter before calculating the maxValue in a DataFrame" in {
       testMetricAggFunction(
         ds,
-        MaxValueMetricCalculator[LongMetric]("number", MetricFilter(col("str") =!= lit("d"), "not d")),
-        LongMetric(3)
+        MaxValueMetricCalculator[OptLongMetric]("number", MetricFilter(col("str") =!= lit("d"), "not d")),
+        OptLongMetric(Some(3))
       )
     }
 
     "handle empty dataset for calculating the maxValue in a DataFrame" in {
       testMetricAggFunction(
         ds.filter(col("number") === 5),
-        MaxValueMetricCalculator[LongMetric]("number", MetricFilter(col("str") =!= lit("d"), "not d")),
-        LongMetric(0)
+        MaxValueMetricCalculator[OptLongMetric]("number", MetricFilter(col("str") =!= lit("d"), "not d")),
+        OptLongMetric(None)
       )
     }
   }

--- a/src/test/scala/com/github/timgent/dataflare/repository/EsMetricsDocumentTest.scala
+++ b/src/test/scala/com/github/timgent/dataflare/repository/EsMetricsDocumentTest.scala
@@ -2,7 +2,7 @@ package com.github.timgent.dataflare.repository
 
 import com.fortysevendeg.scalacheck.datetime.jdk8.ArbitraryJdk8.arbInstantJdk8
 import com.github.timgent.dataflare.checks.DatasourceDescription.SingleDsDescription
-import com.github.timgent.dataflare.metrics.MetricValue.{DoubleMetric, LongMetric}
+import com.github.timgent.dataflare.metrics.MetricValue.{DoubleMetric, LongMetric, OptDoubleMetric, OptLongMetric}
 import com.github.timgent.dataflare.metrics.{MetricValue, SimpleMetricDescriptor}
 import com.github.timgent.dataflare.utils.CommonFixtures._
 import io.circe.parser._
@@ -16,8 +16,12 @@ import com.github.timgent.dataflare.generators.Generators.arbSimpleMetricDescrip
 
 class EsMetricsDocumentTest extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
   private val longMetricGen = Gen.resultOf(LongMetric)
+  private val optLongMetricGen = Gen.resultOf(OptLongMetric)
   private val doubleMetricGen = Gen.resultOf(DoubleMetric)
-  private implicit val arbMetricValue: Arbitrary[MetricValue] = Arbitrary(Gen.oneOf(longMetricGen, doubleMetricGen))
+  private val optDoubleMetricGen = Gen.resultOf(OptDoubleMetric)
+  private implicit val arbMetricValue: Arbitrary[MetricValue] = Arbitrary(
+    Gen.oneOf(longMetricGen, doubleMetricGen, optLongMetricGen, optDoubleMetricGen)
+  )
   implicit private val esMetricsDocumentArb = Arbitrary(for {
     timestamp <- arbInstantJdk8.arbitrary
     datasetDescription <- arbString.arbitrary.map(SingleDsDescription)


### PR DESCRIPTION
The main difference to an end user is now when they use a minValueCheck, regardless of what threshold they used, if the dataframe was empty (if it started that way or became that way due to a filter being applied), then the check would fail. Previously the check would have passed if 0 was within the absoluteThreshold given (as the minValue/maxValue metric was defaulting to 0 for an empty dataframe)